### PR TITLE
insert a refresh interface for async calls

### DIFF
--- a/exchanges/base.py
+++ b/exchanges/base.py
@@ -48,7 +48,7 @@ class ExchangeBase(object):
 
     def refresh(self, callback=None, client_data=None):
         self.data = get_response(self.ticker_url)
-        if callback != None:
+        if callback is not None:
             callback(self, client_data)
 
 class Exchange(ExchangeBase):

--- a/exchanges/base.py
+++ b/exchanges/base.py
@@ -46,9 +46,10 @@ class ExchangeBase(object):
         if self.data == None:
             self.refresh()
 
-    def refresh(self):
+    def refresh(self, callback=None, client_data=None):
         self.data = get_response(self.ticker_url)
-
+        if callback != None:
+            callback(self, client_data)
 
 class Exchange(ExchangeBase):
 


### PR DESCRIPTION
This adds a refresh callback interface that is intended for use in
multithreaded apps that get data from several exchanges.  Using
a callback interface allows the data to get updated immediately
after the caller returns.